### PR TITLE
Fix react-templates

### DIFF
--- a/dist/reactTemplates.js
+++ b/dist/reactTemplates.js
@@ -243,12 +243,16 @@ function generateProps(node, context) {
             props[propKey] = convertText(node, context, val.trim());
         }
 
-        // There is no note as to why this would ever only be run on the client.
-        // What this change does do it break the only use case I care about. We
-        // cannot do client checks as the results of npm run build have
-        // templates expanded.
+        // Note: The correct way to handle require being output in generated
+        // templates is to ensure the output is processed by webpack.
         if (node.name === 'img' && propKey === 'src') {
-            props[propKey] = `require(${ props[propKey] })`;
+            let nv = val.trim();
+            // Remove any leading / so module aliases are easier, the
+            // code should probably be updated but this is currently easier.
+            if (nv[0] === '/') {
+                nv = nv.slice(1);
+            }
+            props[propKey] = `require('${ nv }')`;
         }
     });
     _.assign(props, generateTemplateProps(node, context));

--- a/dist/reactTemplates.js
+++ b/dist/reactTemplates.js
@@ -243,12 +243,12 @@ function generateProps(node, context) {
             props[propKey] = convertText(node, context, val.trim());
         }
 
+        // There is no note as to why this would ever only be run on the client.
+        // What this change does do it break the only use case I care about. We
+        // cannot do client checks as the results of npm run build have
+        // templates expanded.
         if (node.name === 'img' && propKey === 'src') {
-            let evaluated = props[propKey];
-            if (/^"\/?bhf-assets/.test(evaluated)) {
-                evaluated = 'require(' + evaluated.replace(/^"\/?bhf-assets/, '"bhf-assets') + ')';
-            }
-            props[propKey] = evaluated;
+            props[propKey] = `require(${ props[propKey] })`;
         }
     });
     _.assign(props, generateTemplateProps(node, context));

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -245,15 +245,13 @@ function generateProps(node, context) {
             props[propKey] = convertText(node, context, val.trim());
         }
 
-        // Only run this in the client.
+        // There is no note as to why this would ever only be run on the client.
+        // What this change does do it break the only use case I care about. We
+        // cannot do client checks as the results of npm run build have
+        // templates expanded.
         if (node.name === 'img' && propKey === 'src') {
-            let evaluated = props[propKey];
-            if (/^"\/?bhf-assets/.test(evaluated)){
-                evaluated = `( typeof window !== 'undefined' ? require(${evaluated.replace(/^"\/?bhf-assets/, '"bhf-assets')}) : ${evaluated})`;
-            }
-            props[propKey] = evaluated;
+            props[propKey] = `require(${props[propKey]})`;
         }
-
     });
     _.assign(props, generateTemplateProps(node, context));
 

--- a/src/reactTemplates.js
+++ b/src/reactTemplates.js
@@ -245,12 +245,16 @@ function generateProps(node, context) {
             props[propKey] = convertText(node, context, val.trim());
         }
 
-        // There is no note as to why this would ever only be run on the client.
-        // What this change does do it break the only use case I care about. We
-        // cannot do client checks as the results of npm run build have
-        // templates expanded.
+        // Note: The correct way to handle require being output in generated
+        // templates is to ensure the output is processed by webpack.
         if (node.name === 'img' && propKey === 'src') {
-            props[propKey] = `require(${props[propKey]})`;
+          let nv = val.trim();
+          // Remove any leading / so module aliases are easier, the
+          // code should probably be updated but this is currently easier.
+          if (nv[0] === '/') {
+            nv = nv.slice(1);
+          }
+          props[propKey] = `require('${nv}')`;
         }
     });
     _.assign(props, generateTemplateProps(node, context));


### PR DESCRIPTION
This will only work with the changes here:

https://github.com/BasilHealth/bh-frontend/tree/feature/webpack_fixes

Specifically this requires that the server process application.component with webpack before the server starts to ensure the asset hashes work. This ensure that all templates run through webpack and have identical processing.

Both should be deployed at the same time.

This fix ensure assets are run through the asset pipeline when build is run. Without this the old check would only work in the never actually happens case of react-templates being processed when window existed.
